### PR TITLE
Add soversion to the library build.

### DIFF
--- a/libhexagonrpc/meson.build
+++ b/libhexagonrpc/meson.build
@@ -5,6 +5,7 @@ libhexagonrpc = shared_library('hexagonrpc',
   'session.c',
   c_args : cflags,
   include_directories : include,
+  soversion : version,
   install : true
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,7 @@
 project('fastrpc', 'c')
 
+version = '0.3.2'
+
 include = include_directories('include')
 client_target = get_option('libexecdir') / 'hexagonrpc'
 


### PR DESCRIPTION
This add a soversion to the libhexagonrpc, allowing easier upgrade when changing the ABI and would allow a much more standard way to package it in debian.
Meson will generate libhexagonrpc.so.0 and symlink to libhexagonrpc.so
A working debian package with the patch is available at https://salsa.debian.org/xela/hexagonrpc/-/blob/debian/latest/