### PR TITLE
Add man page for hexagonrpcd

### DIFF
--- a/hexagonrpcd/hexagonrpcd.1
+++ b/hexagonrpcd/hexagonrpcd.1
@@ -1,0 +1,55 @@
+'\" t
+.TH HEXAGONRPCD 1 "2024-09-28" "hexagonrpcd" "Server for FastRPC remote procedure calls from Qualcomm DSPs"
+.SH NAME
+hexagonrpcd - Server for FastRPC remote procedure calls from Qualcomm DSPs
+.SH SYNOPSIS
+\fBhexagonrpcd\fP [\fIoptions\&.\&.\&.\fP] -f \fIDEVICE
+.SH DESCRIPTION
+Server for FastRPC remote procedure calls from Qualcomm DSPs\&.
+.PP
+.SH OPTIONS
+.TP
+\fB\-d \fIDSP\fP
+DSP name (default: )
+.TP
+\fB\-f \fIDEVICE\fP
+FastRPC device node to attach to
+.TP
+\fB\-p \fIPROGRAM\fP
+Run client program with shared file descriptor
+.TP
+\fB\-R \fIDIR\fP
+Root directory of served files (default: /usr/share/qcom/)
+.TP
+\fB\-s\fP
+Attach to sensorspd
+.PP
+.SH NOTES
+
+Hexagonrpcd serves files to the remote processor via a reverse tunnel interface
+to the remote processor. These files are by default searched for in:
+
+.TS
+l l
+---
+l l. 
+Physical file/dir                       Android file/dir
+/usr/share/qcom/acdb                    /vendor/etc/acdbdata
+/usr/share/qcom/dsp                     /vendor/dsp
+/usr/share/qcom/sensors/config          /vendor/etc/sensors/config
+/usr/share/qcom/sensors/registry        /mnt/vendor/persist/sensors/registry/registry
+/usr/share/qcom/sensors/sns_reg.conf    /vendor/etc/sensors/sns_reg_config
+/usr/share/qcom/socinfo                 /sys/devices/soc0
+.TE
+
+These files and directories should be populated with files from your device's
+Android firmware.
+
+.SH AUTHORS
+hexagonrpcd was written by The HexagonRPC Contributors <https://github.com/linux-msm/hexagonrpc>
+.SH COPYRIGHT
+Copyright (C) 2024 The HexagonRPC Contributors <https://github.com/linux-msm/hexagonrpc>
+Copyright (C) 2023 The Sensor Shell Contributors <https://github.com/linux-msm/hexagonrpc>
+.PP
+Released under GPL-3+ license\&.
+

--- a/hexagonrpcd/meson.build
+++ b/hexagonrpcd/meson.build
@@ -17,3 +17,4 @@ executable('hexagonrpcd',
   link_with : libhexagonrpc,
   install_dir : get_option('bindir'),
 )
+install_man('hexagonrpcd.1')


### PR DESCRIPTION
This a basic man page for hexagonrpcd created for the future debian package. I've added the meson install_man.