### PR TITLE
Draft: Support for methods with sequences of multi-byte elements, anywhere in argument list

### DIFF
--- a/chrecd/interfaces/chre_slpi.def
+++ b/chrecd/interfaces/chre_slpi.def
@@ -27,4 +27,18 @@
 HEXAGONRPC_DEFINE_REMOTE_METHOD(0, chre_slpi_start_thread, 0, 0, 0, 0)
 HEXAGONRPC_DEFINE_REMOTE_METHOD(1, chre_slpi_wait_on_thread_exit, 0, 0, 0, 0)
 
+HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(0, chre_slpi3_start_thread)
+
+static inline int chre_slpi3_start_thread(const struct fastrpc_context *ctx)
+{
+	return hexagonrpc(&chre_slpi3_start_thread_def, ctx);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(1, chre_slpi3_wait_on_thread_exit)
+
+static inline int chre_slpi3_wait_on_thread_exit(const struct fastrpc_context *ctx)
+{
+	return hexagonrpc(&chre_slpi3_wait_on_thread_exit_def, ctx);
+}
+
 #endif /* INTERFACE_CHRE_SLPI_DEF */

--- a/hexagonrpcd/apps_std.c
+++ b/hexagonrpcd/apps_std.c
@@ -408,15 +408,15 @@ static const struct fastrpc_function_impl apps_std_procs[] = {
 	{ .def = NULL, .impl = NULL, },
 	{ .def = NULL, .impl = NULL, },
 	{
-		.def = &apps_std_fflush_def,
+		.def = &apps_std3_fflush_def,
 		.impl = apps_std_fflush,
 	},
 	{
-		.def = &apps_std_fclose_def,
+		.def = &apps_std3_fclose_def,
 		.impl = apps_std_fclose,
 	},
 	{
-		.def = &apps_std_fread_def,
+		.def = &apps_std3_fread_def,
 		.impl = apps_std_fread,
 	},
 	{ .def = NULL, .impl = NULL, },
@@ -424,7 +424,7 @@ static const struct fastrpc_function_impl apps_std_procs[] = {
 	{ .def = NULL, .impl = NULL, },
 	{ .def = NULL, .impl = NULL, },
 	{
-		.def = &apps_std_fseek_def,
+		.def = &apps_std3_fseek_def,
 		.impl = apps_std_fseek,
 	},
 	{ .def = NULL, .impl = NULL, },
@@ -437,7 +437,7 @@ static const struct fastrpc_function_impl apps_std_procs[] = {
 	{ .def = NULL, .impl = NULL, },
 	{ .def = NULL, .impl = NULL, },
 	{
-		.def = &apps_std_fopen_with_env_def,
+		.def = &apps_std3_fopen_with_env_def,
 		.impl = apps_std_fopen_with_env,
 	},
 	{ .def = NULL, .impl = NULL, },
@@ -447,21 +447,21 @@ static const struct fastrpc_function_impl apps_std_procs[] = {
 	{ .def = NULL, .impl = NULL, },
 	{ .def = NULL, .impl = NULL, },
 	{
-		.def = &apps_std_opendir_def,
+		.def = &apps_std3_opendir_def,
 		.impl = apps_std_opendir,
 	},
 	{
-		.def = &apps_std_closedir_def,
+		.def = &apps_std3_closedir_def,
 		.impl = apps_std_closedir,
 	},
 	{
-		.def = &apps_std_readdir_def,
+		.def = &apps_std3_readdir_def,
 		.impl = apps_std_readdir,
 	},
 	{ .def = NULL, .impl = NULL, },
 	{ .def = NULL, .impl = NULL, },
 	{
-		.def = &apps_std_stat_def,
+		.def = &apps_std3_stat_def,
 		.impl = apps_std_stat,
 	},
 };

--- a/hexagonrpcd/apps_std.c
+++ b/hexagonrpcd/apps_std.c
@@ -20,13 +20,13 @@
  */
 
 #include <errno.h>
+#include <libhexagonrpc/error.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "aee_error.h"
 #include "interfaces/apps_std.def"
 #include "hexagonfs.h"
 #include "iobuffer.h"

--- a/hexagonrpcd/interfaces/adsp_default_listener.def
+++ b/hexagonrpcd/interfaces/adsp_default_listener.def
@@ -26,4 +26,11 @@
 
 HEXAGONRPC_DEFINE_REMOTE_METHOD(0, adsp_default_listener_register, 0, 0, 0, 0)
 
+HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(0, adsp_default_listener3_register)
+
+static inline int adsp_default_listener3_register(const struct fastrpc_context *ctx)
+{
+	return hexagonrpc(&adsp_default_listener3_register_def, ctx);
+}
+
 #endif /* INTERFACE_ADSP_DEFAULT_LISTENER_DEF */

--- a/hexagonrpcd/interfaces/adsp_listener.def
+++ b/hexagonrpcd/interfaces/adsp_listener.def
@@ -29,4 +29,29 @@
 HEXAGONRPC_DEFINE_REMOTE_METHOD(3, adsp_listener_init2, 0, 0, 0, 0)
 HEXAGONRPC_DEFINE_REMOTE_METHOD(4, adsp_listener_next2, 2, 1, 4, 1)
 
+HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(3, adsp_listener3_init2)
+
+static inline int adsp_listener3_init2(int fd)
+{
+	return hexagonrpc2(&adsp_listener3_init2_def, fd, ADSP_LISTENER_HANDLE);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(4, adsp_listener3_next2, true,
+				 0, 0, 1, HEXAGONRPC_DELIMITER, 0, 0, 0, 0, 1)
+
+static inline int adsp_listener3_next2(int fd,
+				       uint32_t ret_rctx,
+				       uint32_t ret_res,
+				       uint32_t ret_outbufs_len, const void *ret_outbufs,
+				       uint32_t *rctx,
+				       uint32_t *handle,
+				       uint32_t *sc,
+				       uint32_t *inbufs_len,
+				       uint32_t inbufs_size, void *inbufs)
+{
+	return hexagonrpc2(&adsp_listener3_next2_def, fd, ADSP_LISTENER_HANDLE,
+			   ret_rctx, ret_res, ret_outbufs_len, ret_outbufs,
+			   rctx, handle, sc, inbufs_len, inbufs_size, inbufs);
+}
+
 #endif /* INTERFACE_ADSP_LISTENER_DEF */

--- a/hexagonrpcd/interfaces/apps_std.def
+++ b/hexagonrpcd/interfaces/apps_std.def
@@ -35,4 +35,162 @@ HEXAGONRPC_DEFINE_REMOTE_METHOD(27, apps_std_closedir, 2, 0, 0, 0)
 HEXAGONRPC_DEFINE_REMOTE_METHOD(28, apps_std_readdir, 2, 0, 66, 0)
 HEXAGONRPC_DEFINE_REMOTE_METHOD(31, apps_std_stat, 1, 1, 24, 0)
 
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(1, apps_std3_freopen, true,
+				 0, HEXAGONRPC_DELIMITER, 0, 1)
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(2, apps_std3_fflush, false,
+				 0, HEXAGONRPC_DELIMITER)
+
+static inline int apps_std3_fflush(struct fastrpc_context *ctx, uint32_t stream)
+{
+	return hexagonrpc(&apps_std3_fflush_def, ctx, stream);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(3, apps_std3_fclose, false,
+				 0, HEXAGONRPC_DELIMITER)
+
+static inline int apps_std3_fclose(struct fastrpc_context *ctx, uint32_t stream)
+{
+	return hexagonrpc(&apps_std3_fclose_def, ctx, stream);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(4, apps_std3_fread, true,
+				 0, HEXAGONRPC_DELIMITER, 0, 0, 1)
+
+static inline int apps_std3_fread(struct fastrpc_context *ctx,
+				  uint32_t stream,
+				  uint32_t *written, uint32_t *is_eof,
+				  uint32_t size, void *buf)
+{
+	return hexagonrpc(&apps_std3_fread_def, ctx,
+			  stream, written, is_eof, size, buf);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(9, apps_std3_fseek, false,
+				 0, 0, 0, HEXAGONRPC_DELIMITER)
+
+static inline int apps_std3_fseek(struct fastrpc_context *ctx,
+				  uint32_t stream, uint32_t pos, uint32_t whence)
+{
+	return hexagonrpc(&apps_std3_fseek_def, ctx, stream, pos, whence);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(19, apps_std3_fopen_with_env, true,
+				 1, 1, 1, 1, HEXAGONRPC_DELIMITER, 0)
+
+static inline int apps_std3_fopen_with_env(struct fastrpc_context *ctx,
+					   uint32_t envvar_len, const char *envvar,
+					   uint32_t delim_len, const char *delim,
+					   uint32_t name_len, const char *name,
+					   uint32_t mode_len, const char *mode)
+{
+	return hexagonrpc(&apps_std3_fopen_with_env_def, ctx,
+			  envvar_len, (const void *) envvar,
+			  delim_len, (const void *) delim,
+			  name_len, (const void *) name,
+			  mode_len, (const void *) mode);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(26, apps_std3_opendir, true,
+				 1, HEXAGONRPC_DELIMITER, 0, 0)
+
+static inline int apps_std3_opendir(struct fastrpc_context *ctx,
+				    uint32_t path_len, const char *path,
+				    uint32_t *handle_lo, uint32_t *handle_hi)
+{
+	return hexagonrpc(&apps_std3_opendir_def, ctx,
+			  path_len, (const void *) path,
+			  handle_lo, handle_hi);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(27, apps_std3_closedir, false,
+				 0, 0, HEXAGONRPC_DELIMITER)
+
+static inline int apps_std3_closedir(struct fastrpc_context *ctx,
+				     uint32_t handle_lo, uint32_t handle_hi)
+{
+	return hexagonrpc(&apps_std3_closedir_def, ctx, handle_lo, handle_hi);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(28, apps_std3_readdir, true,
+				 0, 0, HEXAGONRPC_DELIMITER,
+				 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				 0, 0)
+
+static inline int apps_std3_readdir(struct fastrpc_context *ctx,
+				    uint32_t handle_lo, uint32_t handle_hi,
+				    uint32_t *inode, char *path, uint32_t *eof)
+{
+	uint32_t *buf = (uint32_t *) path;
+
+	return hexagonrpc(&apps_std3_readdir_def, ctx,
+			  handle_lo, handle_hi, inode,
+			  &buf[0], &buf[1], &buf[2], &buf[3],
+			  &buf[4], &buf[5], &buf[6], &buf[7],
+			  &buf[8], &buf[9], &buf[10], &buf[11],
+			  &buf[12], &buf[13], &buf[14], &buf[15],
+			  &buf[16], &buf[17], &buf[18], &buf[19],
+			  &buf[20], &buf[21], &buf[22], &buf[23],
+			  &buf[24], &buf[25], &buf[26], &buf[27],
+			  &buf[28], &buf[29], &buf[30], &buf[31],
+			  &buf[32], &buf[33], &buf[34], &buf[35],
+			  &buf[36], &buf[37], &buf[38], &buf[39],
+			  &buf[40], &buf[41], &buf[42], &buf[43],
+			  &buf[44], &buf[45], &buf[46], &buf[47],
+			  &buf[48], &buf[49], &buf[50], &buf[51],
+			  &buf[52], &buf[53], &buf[54], &buf[55],
+			  &buf[56], &buf[57], &buf[58], &buf[57],
+			  &buf[60], &buf[61], &buf[62], &buf[63], eof);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(29, apps_std3_mkdir, false,
+				 1, 0, HEXAGONRPC_DELIMITER)
+
+static inline int apps_std3_mkdir(struct fastrpc_context *ctx,
+				  uint32_t path_size, const char *path,
+				  uint32_t mode)
+{
+	return hexagonrpc(&apps_std3_mkdir_def, ctx,
+			  path_size, (const void *) path, mode);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(31, apps_std3_stat, true,
+				 1, HEXAGONRPC_DELIMITER,
+				 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				 0, 0, 0, 0, 0, 0, 0, 0)
+
+static inline int apps_std3_stat(struct fastrpc_context *ctx,
+				 uint32_t path_size, const char *path,
+				 uint32_t *tsz_lo, uint32_t *tsz_hi,
+				 uint32_t *dev_lo, uint32_t *dev_hi,
+				 uint32_t *ino_lo, uint32_t *ino_hi,
+				 uint32_t *mode, uint32_t *nlink,
+				 uint32_t *rdev_lo, uint32_t *rdev_hi,
+				 uint32_t *size_lo, uint32_t *size_hi,
+				 uint32_t *atime_sec_lo, uint32_t *atime_sec_hi,
+				 uint32_t *atime_nsec_lo, uint32_t *atime_nsec_hi,
+				 uint32_t *mtime_sec_lo, uint32_t *mtime_sec_hi,
+				 uint32_t *mtime_nsec_lo, uint32_t *mtime_nsec_hi,
+				 uint32_t *ctime_sec_lo, uint32_t *ctime_sec_hi,
+				 uint32_t *ctime_nsec_lo, uint32_t *ctime_nsec_hi)
+{
+	return hexagonrpc(&apps_std3_stat_def, ctx,
+			  path_size, (const void *) path,
+			  tsz_lo, tsz_hi,
+			  dev_lo, dev_hi,
+			  ino_lo, ino_hi,
+			  mode, nlink,
+			  rdev_lo, rdev_hi,
+			  size_lo, size_hi,
+			  atime_sec_lo, atime_sec_hi,
+			  atime_nsec_lo, atime_nsec_hi,
+			  mtime_sec_lo, mtime_sec_hi,
+			  mtime_nsec_lo, mtime_nsec_hi,
+			  ctime_sec_lo, ctime_sec_hi,
+			  ctime_nsec_lo, ctime_nsec_hi);
+}
+
 #endif /* INTERFACE_APPS_STD_DEF */

--- a/hexagonrpcd/listener.c
+++ b/hexagonrpcd/listener.c
@@ -30,32 +30,6 @@
 #include "iobuffer.h"
 #include "listener.h"
 
-static int adsp_listener_init2(int fd)
-{
-	return fastrpc2(&adsp_listener_init2_def, fd, ADSP_LISTENER_HANDLE);
-}
-
-static int adsp_listener_next2(int fd,
-			       uint32_t ret_rctx,
-			       uint32_t ret_res,
-			       uint32_t ret_outbuf_len, void *ret_outbuf,
-			       uint32_t *rctx,
-			       uint32_t *handle,
-			       uint32_t *sc,
-			       uint32_t *inbufs_len,
-			       uint32_t inbufs_size, void *inbufs)
-{
-	return fastrpc2(&adsp_listener_next2_def, fd, ADSP_LISTENER_HANDLE,
-			ret_rctx,
-			ret_res,
-			ret_outbuf_len, ret_outbuf,
-			rctx,
-			handle,
-			sc,
-			inbufs_len,
-			inbufs_size, inbufs);
-}
-
 static struct fastrpc_io_buffer *allocate_outbufs(const struct fastrpc_function_def_interp2 *def,
 						  uint32_t *first_inbuf)
 {
@@ -160,7 +134,7 @@ static int return_for_next_invoke(int fd,
 		outbufs_encode(REMOTE_SCALARS_OUTBUFS(*sc), returned, outbufs);
 	}
 
-	ret = adsp_listener_next2(fd,
+	ret = adsp_listener3_next2(fd,
 				  *rctx, result,
 				  outbufs_len, outbufs,
 				  rctx, handle, sc,
@@ -290,7 +264,7 @@ int run_fastrpc_listener(int fd,
 	uint32_t n_outbufs = 0;
 	int ret;
 
-	ret = adsp_listener_init2(fd);
+	ret = adsp_listener3_init2(fd);
 	if (ret) {
 		fprintf(stderr, "Could not initialize the listener: %u\n", ret);
 		return ret;

--- a/hexagonrpcd/listener.c
+++ b/hexagonrpcd/listener.c
@@ -20,12 +20,12 @@
  */
 
 #include <inttypes.h>
+#include <libhexagonrpc/error.h>
 #include <libhexagonrpc/fastrpc.h>
 #include <libhexagonrpc/interfaces/remotectl.def>
 #include <stddef.h>
 #include <stdio.h>
 
-#include "aee_error.h"
 #include "interfaces/adsp_listener.def"
 #include "iobuffer.h"
 #include "listener.h"

--- a/hexagonrpcd/listener.h
+++ b/hexagonrpcd/listener.h
@@ -29,7 +29,7 @@
 #include "iobuffer.h"
 
 struct fastrpc_function_impl {
-	const struct fastrpc_function_def_interp2 *def;
+	const struct hrpc_method_def_interp3 *def;
 	uint32_t (*impl)(void *data,
 			 const struct fastrpc_io_buffer *inbufs,
 			 struct fastrpc_io_buffer *outbufs);

--- a/hexagonrpcd/localctl.c
+++ b/hexagonrpcd/localctl.c
@@ -145,8 +145,14 @@ void fastrpc_localctl_deinit(struct fastrpc_interface *iface)
 }
 
 static const struct fastrpc_function_impl localctl_procs[] = {
-	{ .def = &remotectl_open_def, .impl = localctl_open, },
-	{ .def = &remotectl_close_def, .impl = localctl_close, },
+	{
+		.def = &remotectl3_open_def,
+		.impl = localctl_open,
+	},
+	{
+		.def = &remotectl3_close_def,
+		.impl = localctl_close,
+	},
 };
 
 const struct fastrpc_interface localctl_interface = {

--- a/hexagonrpcd/localctl.c
+++ b/hexagonrpcd/localctl.c
@@ -19,13 +19,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <libhexagonrpc/error.h>
 #include <libhexagonrpc/interfaces/remotectl.def>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "aee_error.h"
 #include "iobuffer.h"
 #include "listener.h"
 #include "localctl.h"

--- a/hexagonrpcd/meson.build
+++ b/hexagonrpcd/meson.build
@@ -1,5 +1,4 @@
 executable('hexagonrpcd',
-  'aee_error.c',
   'apps_std.c',
   'interfaces.c',
   'hexagonfs.c',

--- a/hexagonrpcd/rpcd.c
+++ b/hexagonrpcd/rpcd.c
@@ -94,11 +94,6 @@ static int remotectl_close(struct fastrpc_context *ctx, void (*err_cb)(const cha
 	return ret;
 }
 
-static int adsp_default_listener_register(struct fastrpc_context *ctx)
-{
-	return fastrpc(&adsp_default_listener_register_def, ctx);
-}
-
 static void remotectl_err(const char *err)
 {
 	fprintf(stderr, "Could not remotectl: %s\n", err);
@@ -113,7 +108,7 @@ static int register_fastrpc_listener(int fd)
 	if (ret)
 		return 1;
 
-	ret = adsp_default_listener_register(ctx);
+	ret = adsp_default_listener3_register(ctx);
 	if (ret) {
 		fprintf(stderr, "Could not register ADSP default listener\n");
 		goto err;

--- a/hexagonrpcd/rpcd.c
+++ b/hexagonrpcd/rpcd.c
@@ -21,6 +21,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <libhexagonrpc/error.h>
 #include <libhexagonrpc/fastrpc.h>
 #include <libhexagonrpc/interfaces/remotectl.def>
 #include <misc/fastrpc.h>
@@ -32,7 +33,6 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 
-#include "aee_error.h"
 #include "apps_std.h"
 #include "hexagonfs.h"
 #include "interfaces/adsp_default_listener.def"
@@ -53,16 +53,13 @@ static int remotectl_open(int fd, char *name, struct fastrpc_context **ctx, void
 		       &dlret,
 		       256, err);
 
-	if (ret == -1) {
-		err_cb(strerror(errno));
+	if (ret) {
+		err_cb(hexagonrpc_strerror(errno));
 		return ret;
 	}
 
-	if (dlret == -5) {
+	if (dlret) {
 		err_cb(err);
-		return dlret;
-	} else if (dlret) {
-		err_cb(aee_strerror[dlret]);
 		return dlret;
 	}
 
@@ -82,13 +79,13 @@ static int remotectl_close(struct fastrpc_context *ctx, void (*err_cb)(const cha
 		       &dlret,
 		       256, err);
 
-	if (ret == -1) {
-		err_cb(strerror(errno));
+	if (ret) {
+		err_cb(hexagonrpc_strerror(errno));
 		return ret;
 	}
 
 	if (dlret) {
-		err_cb(aee_strerror[dlret]);
+		err_cb(err);
 		return dlret;
 	}
 

--- a/include/libhexagonrpc/error.h
+++ b/include/libhexagonrpc/error.h
@@ -2,6 +2,7 @@
  * Imported FastRPC error numbers
  *
  * Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2023, The Sensor Shell Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -83,6 +84,6 @@
 #define AEE_ECPUEXCEPTION	48
 #define AEE_EREADONLY		49
 
-extern const char *aee_strerror[];
+const char *hexagonrpc_strerror(int ret);
 
 #endif

--- a/include/libhexagonrpc/fastrpc.h
+++ b/include/libhexagonrpc/fastrpc.h
@@ -23,6 +23,7 @@
 #define FASTRPC_H
 
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -41,6 +42,8 @@
 #define REMOTE_SCALARS_INBUFS(sc) (((sc) >> 16) & 0xff)
 #define REMOTE_SCALARS_OUTBUFS(sc) (((sc) >> 8) & 0xff)
 
+#define HEXAGONRPC_DELIMITER 0xFFFFFFFF
+
 struct fastrpc_context {
 	int fd;
 	uint32_t handle;
@@ -52,6 +55,13 @@ struct fastrpc_function_def_interp2 {
 	uint8_t in_bufs;
 	uint8_t out_nums;
 	uint8_t out_bufs;
+};
+
+struct hrpc_method_def_interp3 {
+	uint32_t msg_id;
+	bool has_prim_out;
+	size_t n_args;
+	const uint32_t *args;
 };
 
 struct fastrpc_context *fastrpc_create_context(int fd, uint32_t handle);
@@ -69,5 +79,15 @@ int fastrpc2(const struct fastrpc_function_def_interp2 *def,
 	     int fd, uint32_t handle, ...);
 int fastrpc(const struct fastrpc_function_def_interp2 *def,
 	    const struct fastrpc_context *ctx, ...);
+
+int vhexagonrpc2(const struct hrpc_method_def_interp3 *def,
+		 int fd, uint32_t handle, va_list list);
+int vhexagonrpc(const struct hrpc_method_def_interp3 *def,
+		const struct fastrpc_context *ctx, va_list list);
+int hexagonrpc2(const struct hrpc_method_def_interp3 *def,
+		int fd, uint32_t handle, ...);
+int hexagonrpc(const struct hrpc_method_def_interp3 *def,
+	       const struct fastrpc_context *ctx, ...);
+
 
 #endif

--- a/include/libhexagonrpc/interface.h
+++ b/include/libhexagonrpc/interface.h
@@ -36,6 +36,12 @@
 					outnums, outbufs)		\
 	extern const struct fastrpc_function_def_interp2 name##_def;
 
+#define HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(mid, name)	\
+	extern const struct hrpc_method_def_interp3 name##_def;
+
+#define HEXAGONRPC_DEFINE_REMOTE_METHOD3(mid, name, has_oprim, ...)	\
+	HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(mid, name)
+
 #else /* HEXAGONRPC_BUILD_METHOD_DEFINITIONS */
 
 #define HEXAGONRPC_DEFINE_REMOTE_METHOD(mid, name,			\
@@ -47,6 +53,23 @@
 		.in_bufs = inbufs,					\
 		.out_nums = outnums,					\
 		.out_bufs = outbufs,					\
+	};
+
+#define HEXAGONRPC_DEFINE_REMOTE_METHOD3_EMPTY(mid, name)	\
+	const struct hrpc_method_def_interp3 name##_def = {	\
+		.msg_id = mid,					\
+		.has_prim_out = false,				\
+		.n_args = 0,					\
+		.args = NULL,					\
+	};
+
+#define HEXAGONRPC_DEFINE_REMOTE_METHOD3(mid, name, has_oprim, ...)	\
+	static const uint32_t name##_args[] = { __VA_ARGS__ };		\
+	const struct hrpc_method_def_interp3 name##_def = {		\
+		.msg_id = mid,						\
+		.has_prim_out = has_oprim,				\
+		.n_args = sizeof(name##_args) / sizeof(*name##_args),	\
+		.args = name##_args,					\
 	};
 
 #endif /* HEXAGONRPC_BUILD_METHOD_DEFINITIONS */

--- a/include/libhexagonrpc/interfaces/remotectl.def
+++ b/include/libhexagonrpc/interfaces/remotectl.def
@@ -29,4 +29,30 @@
 HEXAGONRPC_DEFINE_REMOTE_METHOD(0, remotectl_open, 0, 1, 2, 1)
 HEXAGONRPC_DEFINE_REMOTE_METHOD(1, remotectl_close, 1, 0, 1, 1)
 
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(0, remotectl3_open, true,
+				 1, HEXAGONRPC_DELIMITER, 0, 1, 0)
+
+static inline int remotectl3_open(int fd,
+				  uint32_t n_str, const char *str,
+				  uint32_t *handle,
+				  uint32_t err_len, char *err,
+				  uint32_t *dlerr)
+{
+	return hexagonrpc2(&remotectl3_open_def, fd, REMOTECTL_HANDLE,
+			   n_str, (const void *) str,
+			   handle, err_len, (void *) err, dlerr);
+}
+
+HEXAGONRPC_DEFINE_REMOTE_METHOD3(0, remotectl3_close, true,
+				 0, HEXAGONRPC_DELIMITER, 1, 0)
+
+static inline int remotectl3_close(int fd,
+				   uint32_t handle,
+				   uint32_t err_len, char *err,
+				   uint32_t *dlerr)
+{
+	return hexagonrpc2(&remotectl3_close_def, fd, REMOTECTL_HANDLE,
+			   handle, err_len, (void *) err, dlerr);
+}
+
 #endif /* INTERFACE_REMOTECTL_DEF */

--- a/libhexagonrpc/context.c
+++ b/libhexagonrpc/context.c
@@ -54,3 +54,21 @@ int fastrpc(const struct fastrpc_function_def_interp2 *def,
 	return ret;
 }
 
+int vhexagonrpc(const struct hrpc_method_def_interp3 *def,
+		const struct fastrpc_context *ctx, va_list arg_list)
+{
+	return vhexagonrpc2(def, ctx->fd, ctx->handle, arg_list);
+}
+
+int hexagonrpc(const struct hrpc_method_def_interp3 *def,
+	       const struct fastrpc_context *ctx, ...)
+{
+	va_list arg_list;
+	int ret;
+
+	va_start(arg_list, ctx);
+	ret = vhexagonrpc(def, ctx, arg_list);
+	va_end(arg_list);
+
+	return ret;
+}

--- a/libhexagonrpc/error.c
+++ b/libhexagonrpc/error.c
@@ -2,6 +2,7 @@
  * Imported FastRPC error messages
  *
  * Copyright (c) 2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2023, The Sensor Shell Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -29,7 +30,10 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-const char *aee_strerror[] = {
+#include <errno.h>
+#include <string.h>
+
+static const char *err_tab[] = {
 	"No error",
 	"General failure",
 	"Insufficient RAM",
@@ -81,3 +85,13 @@ const char *aee_strerror[] = {
 	"A CPU exception occurred",
 	"Cannot change read-only object or parameter",
 };
+
+const char *hexagonrpc_strerror(int ret)
+{
+	if (ret == -1)
+		return strerror(errno);
+	else if (ret >= 0 && (unsigned int) ret < sizeof(err_tab) / sizeof(*err_tab))
+		return err_tab[ret];
+
+	return "Unknown error";
+}

--- a/libhexagonrpc/fastrpc.c
+++ b/libhexagonrpc/fastrpc.c
@@ -250,3 +250,221 @@ int fastrpc2(const struct fastrpc_function_def_interp2 *def,
 
 	return ret;
 }
+
+/*
+ * This populates relevant arguments with information necessary to receive
+ * output from the remote processor.
+ *
+ * First, it allocates a new first output buffer to contain the returned 32-bit
+ * integers. This output buffer must be freed after use.
+ *
+ * With a peek at the output arguments, it populates the fastrpc_invoke_args
+ * struct to give information about the provided buffers to the kernel, and
+ * adds an entry to the first input buffer to tell the remote processor the
+ * size of the function-level output buffer.
+ */
+static void prepare_outbufs3(const struct hrpc_method_def_interp3 *def,
+			     struct fastrpc_invoke_args *args,
+			     size_t delim,
+			     uint32_t *n_prim_in, uint8_t *n_outbufs,
+			     uint32_t *prim,
+			     va_list peek)
+{
+	uint32_t n_prim_out = 0;
+	size_t i;
+
+	if (def->has_prim_out)
+		*n_outbufs = 1;
+	else
+		*n_outbufs = 0;
+
+	for (i = delim; i < def->n_args; i++) {
+		if (def->args[i]) {
+			prim[*n_prim_in] = va_arg(peek, uint32_t);
+
+			args[*n_outbufs].length = prim[*n_prim_in] * def->args[i];
+			args[*n_outbufs].ptr = (__u64) va_arg(peek, void *);
+			args[*n_outbufs].fd = -1;
+
+			(*n_prim_in)++;
+			(*n_outbufs)++;
+		} else {
+			va_arg(peek, uint32_t *);
+			n_prim_out++;
+		}
+	}
+
+	if (def->has_prim_out) {
+		args[0].length = sizeof(uint32_t) * n_prim_out;
+		args[0].ptr = (__u64) &prim[*n_prim_in];
+		args[0].fd = -1;
+	}
+}
+
+static void return_prim_out(const struct hrpc_method_def_interp3 *def,
+			    size_t delim,
+			    const uint32_t *prim_out,
+			    va_list list)
+{
+	uint32_t *ptr;
+	size_t i, j = 0;
+
+	for (i = delim; i < def->n_args; i++) {
+		if (def->args[i]) {
+			va_arg(list, uint32_t);
+			va_arg(list, void *);
+		} else {
+			ptr = va_arg(list, uint32_t *);
+			*ptr = prim_out[j];
+			j++;
+		}
+	}
+}
+
+/*
+ * This is the main function to invoke a FastRPC procedure call. The first
+ * parameter specifies how to populate the ioctl-level buffers. The second and
+ * third parameters specify where to send the invocation to. The fourth is the
+ * list of arguments that the procedure call should interact with.
+ *
+ * A good example for this would be the adsp_listener_next2 call:
+ *
+ * static inline void adsp_listener_next2(int fd, uint32_t handle,
+ *					  uint32_t prev_ctx,
+ *					  uint32_t prev_result,
+ *					  uint32_t nested_outbufs_len,
+ *					  void *nested_outbufs,
+ *					  uint32_t *ctx,
+ *					  uint32_t *nested_handle,
+ *					  uint32_t *nested_sc,
+ *					  uint32_t *nested_inbufs_len,
+ *					  uint32_t nested_inbufs_size,
+ *					  void *nested_inbufs)
+ * {
+ *   uint32_t args[] = { 0, 0, 1, HEXAGONRPC_DELIMITER, 0, 0, 0, 1 };
+ *   struct hrpc_method_def_interp3 def = {
+ *     .mid = 4,
+ *     .has_out_prim = true,
+ *     .n_args = 8,
+ *     .args = args,
+ *   };
+ *   return vhexagonrpc2(def, fd, handle,
+ *			 prev_ctx,
+ *			 prev_result,
+ *			 nested_outbufs_len,
+ *			 nested_outbufs,
+ *			 ctx,
+ *			 nested_handle,
+ *			 nested_sc,
+ *			 nested_inbufs_len,
+ *			 nested_inbufs_size,
+ *			 nested_inbufs);
+ * }
+ */
+int vhexagonrpc2(const struct hrpc_method_def_interp3 *def,
+		 int fd, uint32_t handle, va_list list)
+{
+	va_list peek;
+	struct fastrpc_invoke invoke;
+	struct fastrpc_invoke_args *args;
+	uint32_t *prim;
+	uint32_t n_prim_in = 0;
+	uint32_t msg_id;
+	uint8_t n_inbufs = 1, n_outbufs;
+	size_t i;
+	int ret = -1;
+
+	/*
+	 * If there are only input buffers specified in the method definition,
+	 * we need an extra primary input argument for their sizes.
+	 */
+	args = malloc(sizeof(struct fastrpc_invoke_args) * (def->n_args + 1));
+	if (args == NULL)
+		return -1;
+
+	/*
+	 * The input and output buffers need a size in the primary input buffer
+	 * so all arguments except the optional delimiter contribute to the
+	 * primary buffers.
+	 */
+	prim = malloc(sizeof(uint32_t) * (def->n_args + 1));
+	if (prim == NULL)
+		goto err_free_args;
+
+	/*
+	 * The apps_std interface demonstrates that there is support
+	 * for more than 32 methods for a single interface. Support
+	 * extended method IDs that go beyond 5 bits and the ID
+	 * reserved for this purpose.
+	 */
+	if (def->msg_id >= 31) {
+		prim[n_prim_in] = def->msg_id;
+		n_prim_in++;
+		msg_id = 31;
+	} else {
+		msg_id = def->msg_id;
+	}
+
+	for (i = 0; i < def->n_args; i++) {
+		if (def->args[i] == HEXAGONRPC_DELIMITER) {
+			i++;
+			break;
+		}
+
+		prim[n_prim_in] = va_arg(list, uint32_t);
+
+		if (def->args[i]) {
+			args[n_inbufs].length = prim[n_prim_in] * def->args[i];
+			args[n_inbufs].ptr = (__u64) va_arg(list, const void *);
+			args[n_inbufs].fd = -1;
+			n_inbufs++;
+		}
+
+		n_prim_in++;
+	}
+
+	va_copy(peek, list);
+	prepare_outbufs3(def, &args[n_inbufs], i, &n_prim_in, &n_outbufs, prim, peek);
+	va_end(peek);
+
+	args[0].length = sizeof(uint32_t) * n_prim_in;
+	args[0].ptr = (__u64) prim;
+	args[0].fd = -1;
+
+	// Pass the primary input buffer if not empty, otherwise skip it.
+	if (n_prim_in != 0) {
+		invoke.args = (__u64) args;
+	} else {
+		invoke.args = (__u64) &args[1];
+		n_inbufs--;
+	}
+
+	invoke.handle = handle;
+	invoke.sc = REMOTE_SCALARS_MAKE(msg_id, n_inbufs, n_outbufs);
+
+	ret = ioctl(fd, FASTRPC_IOCTL_INVOKE, (__u64) &invoke);
+	if (ret == -1)
+		goto err_free_prim;
+
+	return_prim_out(def, i, &prim[n_prim_in], list);
+
+err_free_prim:
+	free(prim);
+err_free_args:
+	free(args);
+
+	return ret;
+}
+
+int hexagonrpc2(const struct hrpc_method_def_interp3 *def,
+		int fd, uint32_t handle, ...)
+{
+	va_list list;
+	int ret;
+
+	va_start(list, handle);
+	ret = vhexagonrpc2(def, fd, handle, list);
+	va_end(list);
+
+	return ret;
+}

--- a/libhexagonrpc/meson.build
+++ b/libhexagonrpc/meson.build
@@ -1,5 +1,6 @@
 libhexagonrpc = shared_library('hexagonrpc',
   'context.c',
+  'error.c',
   'fastrpc.c',
   'interfaces.c',
   'session.c',


### PR DESCRIPTION
This is the change proposed to solve #1. There are things that aren't solved here yet, like missing support for methods after method ID 30.