### PR TITLE
 Use Major.Minor for the lib soversion derived from project version

### DIFF
--- a/libhexagonrpc/meson.build
+++ b/libhexagonrpc/meson.build
@@ -5,7 +5,7 @@ libhexagonrpc = shared_library('hexagonrpc',
   'session.c',
   c_args : cflags,
   include_directories : include,
-  soversion : version,
+  soversion : api_version,
   install : true
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
-project('fastrpc', 'c')
+project('fastrpc', 'c', version: '0.3.2')
 
-version = '0.3.2'
+version_array = meson.project_version().split('.')
+api_version = version_array[0] + '.' + version_array[1]
 
 include = include_directories('include')
 client_target = get_option('libexecdir') / 'hexagonrpc'


### PR DESCRIPTION
The main version is now set as the meson project version , and a variable api_version representing the version in the form of "major.minor" and use has the library soversion.
This would allow to break the ABI in all minor version but let it be stable for fixes, it would greatly simplify the updating of the debian package (which use this convention libfoo$SOVERSION).

